### PR TITLE
add spread operator for attributes

### DIFF
--- a/lib/CSSX.js
+++ b/lib/CSSX.js
@@ -60,6 +60,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  value: true
 	});
 	
+	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+	
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 	
 	var _react = __webpack_require__(1);
@@ -87,7 +89,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  function CSSX(props) {
 	    _classCallCheck(this, CSSX);
 	
-	    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(CSSX).call(this, props));
+	    var _this = _possibleConstructorReturn(this, (CSSX.__proto__ || Object.getPrototypeOf(CSSX)).call(this, props));
 	
 	    var sheet = cssx(getID('cssx-styles'));
 	    var cssScopeId = getID('cssx-el');
@@ -107,7 +109,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'render',
 	    value: function render() {
 	      this.state.sheet.add(this.props.styles);
-	      return _react2.default.createElement(this.props['data-element'], { id: this.state.cssScopeId }, this.props.children);
+	      return _react2.default.createElement(this.props['data-element'], _extends({
+	        id: this.state.cssScopeId
+	      }, this.props), this.props.children);
 	    }
 	  }]);
 	

--- a/src/CSSX.jsx
+++ b/src/CSSX.jsx
@@ -24,7 +24,10 @@ export default class CSSX extends React.Component {
     this.state.sheet.add(this.props.styles);
     return React.createElement(
       this.props['data-element'],
-      { id: this.state.cssScopeId },
+      {
+        id: this.state.cssScopeId,
+        ...this.props,
+      },
       this.props.children
     );
   }


### PR DESCRIPTION
As we can't remove the wrappers completely for now ([#10](https://github.com/krasimir/react-cssx/pull/10#issuecomment-248887139)), let's make them more flexible!

this PR allow the wrapper to have attributes defined to it, e.g. `className`.
It will solve at least one of the problems described on [#5](https://github.com/krasimir/react-cssx/issues/5#issuecomment-248842579).
