### PR TITLE
Styles is not an accepted attribute for div's

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015": "6.14.0",
     "babel-preset-es2016": "6.11.3",
     "babel-preset-react": "6.11.1",
+    "babel-preset-stage-2": "^6.22.0",
     "cssx-loader": "5.2.0",
     "react": "15.3.2",
     "react-dom": "15.3.2",

--- a/src/CSSX.jsx
+++ b/src/CSSX.jsx
@@ -22,11 +22,17 @@ export default class CSSX extends React.Component {
   }
   render() {
     this.state.sheet.add(this.props.styles);
+
+    var props = { ...this.props };
+    if (this.props['data-element'] === CSSX.defaultProps['data-element']) {
+      delete props.styles;
+    }
+
     return React.createElement(
       this.props['data-element'],
       {
         id: this.state.cssScopeId,
-        ...this.props,
+        ...props,
       },
       this.props.children
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
         exclude: /(node_modules|bower_components)/,
         loader: 'babel',
         query: {
-          presets: ['react', 'es2015']
+          presets: ['react', 'es2015', 'stage-2']
         }
       }
     ]


### PR DESCRIPTION
When using this library React will start to complain that `styles` is not a supported attribute on div's
This PR adresses that issue.

Also when just cloning the project and trying to build using `npm run build` it will fail due to the spread operator. Adding the babel stage 2 preset fixes this.